### PR TITLE
feat(editor): Add refresh button to sync DataTable details view

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -63,6 +63,7 @@ const classes = computed(() => {
 		:disabled="isDisabled"
 		:aria-disabled="ariaDisabled"
 		:aria-busy="ariaBusy"
+		:aria-label="ariaLabel"
 		:href="href"
 		aria-live="polite"
 		v-bind="{

--- a/packages/frontend/@n8n/design-system/src/types/button.ts
+++ b/packages/frontend/@n8n/design-system/src/types/button.ts
@@ -38,6 +38,7 @@ export interface IconButtonProps {
 }
 
 export interface ButtonProps extends IconButtonProps {
+	ariaLabel?: string;
 	block?: boolean;
 	element?: ButtonElement;
 	href?: string;

--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.test.ts
@@ -5,7 +5,7 @@ import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import { useToast } from '@/app/composables/useToast';
 import { useRouter } from 'vue-router';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
-import { waitFor } from '@testing-library/vue';
+import { waitFor, fireEvent } from '@testing-library/vue';
 
 vi.mock('@/app/composables/useToast');
 vi.mock('vue-router');
@@ -56,6 +56,8 @@ const DEFAULT_DATA_TABLE: DataTable = {
 	projectId: 'proj1',
 };
 
+const mockRefresh = vi.fn().mockResolvedValue(DEFAULT_DATA_TABLE);
+
 const renderComponent = createComponentRenderer(DataTableDetailsView, {
 	props: {
 		id: 'ds1',
@@ -64,7 +66,15 @@ const renderComponent = createComponentRenderer(DataTableDetailsView, {
 	global: {
 		stubs: {
 			DataTableBreadcrumbs: true,
-			DataTableTable: true,
+			DataTableTable: {
+				template: '<div data-testid="data-table-table"><slot /></div>',
+				methods: {
+					addColumn: vi.fn(),
+					addRow: vi.fn(),
+					refreshData: mockRefresh,
+				},
+				data: () => ({ gridData: [] }),
+			},
 		},
 	},
 });
@@ -130,7 +140,7 @@ describe('DataTableDetailsView', () => {
 
 			await waitFor(() => {
 				expect(container.querySelector('data-table-breadcrumbs-stub')).toBeInTheDocument();
-				expect(container.querySelector('data-table-table-stub')).toBeInTheDocument();
+				expect(container.querySelector('[data-testid="data-table-table"]')).toBeInTheDocument();
 			});
 		});
 
@@ -179,6 +189,25 @@ describe('DataTableDetailsView', () => {
 				);
 				expect(mockRouter.push).toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe('Actions', () => {
+		it('should handle refresh action', async () => {
+			const pinia = createTestingPinia({ stubActions: false });
+			const dataTableStore = useDataTableStore();
+			vi.spyOn(dataTableStore, 'fetchOrFindDataTable').mockResolvedValue(DEFAULT_DATA_TABLE);
+
+			const { findByRole } = renderComponent({ pinia });
+
+			const refreshButton = await findByRole('button', { name: 'refresh' });
+
+			expect(refreshButton).toBeInTheDocument();
+			expect(dataTableStore.fetchOrFindDataTable).toHaveBeenCalledTimes(1);
+
+			await fireEvent.click(refreshButton);
+
+			expect(mockRefresh).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
@@ -107,6 +107,16 @@ const onAddColumn = async (column: DataTableColumnCreatePayload): Promise<AddCol
 	return await dataTableTableRef.value.addColumn(column);
 };
 
+const onRefresh = async () => {
+	if (!dataTableTableRef.value) {
+		return {
+			success: false,
+			errorMessage: i18n.baseText('dataTable.error.tableNotInitialized'),
+		};
+	}
+	return await dataTableTableRef.value.refreshData();
+};
+
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('dataTable.dataTables'));
 	await initialize();
@@ -164,6 +174,13 @@ onMounted(async () => {
 						:popover-id="'ds-details-add-column-popover'"
 						:params="{ onAddColumn }"
 					/>
+					<N8nButton
+						@click="onRefresh"
+						ariaLabel="refresh"
+						icon="refresh-cw"
+						square
+						type="tertiary"
+					></N8nButton>
 				</div>
 			</div>
 			<div :class="$style.content">

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
@@ -161,6 +161,7 @@ watch(
 defineExpose({
 	addRow: dataTableOperations.onAddRowClick,
 	addColumn: dataTableOperations.onAddColumn,
+	refreshData: fetchDataTableRowsFunction,
 });
 </script>
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Add a “Refresh” button in the DataTable details view, next to the “Add column” button: it syncs table data, without the need to refresh the entire web page.

Refresh is also aligned with the current pagination setup.

_Why_
During the “dev” phase of a workflow using DataTable, I found myself in need to continuously check, set and reset data in the table (opened in a different browser tab). There was no way to sync the data in the table without reloading the entire web page.


![refresh-button-data-store-details-view_nicola_abis](https://github.com/user-attachments/assets/7e0804f2-57fd-46a4-8bf7-8c90fb9f217d)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Feature request post in Community forum: [200590](https://community.n8n.io/t/refresh-table-data-button-in-datastore-details-view/200590)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
